### PR TITLE
Fixed wrong module name in config.xml

### DIFF
--- a/app/code/community/Xonu/FGP/etc/config.xml
+++ b/app/code/community/Xonu/FGP/etc/config.xml
@@ -7,9 +7,9 @@
 -->
 <config>
 	<modules>
-		<Xonu_SBE>
+		<Xonu_FGP>
 			<version>2.0.0</version>
-		</Xonu_SBE>
+		</Xonu_FGP>
 	</modules>
 	<global>
         <models>


### PR DESCRIPTION
The module name in app/etc/modules/Xonu_FGB.xml and app/code/community/Xonu/FGB/etc/config.xml should be the same.
